### PR TITLE
add cascade delete for some tables, so upsert operation will be more …

### DIFF
--- a/open_bus_stride_db/model/gtfs_route.py
+++ b/open_bus_stride_db/model/gtfs_route.py
@@ -16,5 +16,5 @@ class GtfsRoute(Base):
     route_alternative = sqlalchemy.Column(sqlalchemy.String)
     agency_name = sqlalchemy.Column(sqlalchemy.String)
     route_type = sqlalchemy.Column(sqlalchemy.String)
-    gtfs_route_stops = sqlalchemy.orm.relationship('GtfsRouteStop', back_populates='gtfs_route')
-    gtfs_rides = sqlalchemy.orm.relationship('GtfsRide', back_populates='gtfs_route')
+    gtfs_route_stops = sqlalchemy.orm.relationship('GtfsRouteStop', back_populates='gtfs_route', cascade="all, delete")
+    gtfs_rides = sqlalchemy.orm.relationship('GtfsRide', back_populates='gtfs_route', cascade="all, delete")


### PR DESCRIPTION
while working on hasadna/open-bus#348 i discovered that it is better to define delete cascade in some GTFS tables so while deleting route record the related records in gtfs_route_stops and gtfs_rides tables will be deleted as well. in case this option is turned off the default behavior of SQLAlchemy is to modify remove the foreign key in the records there and there is no point for that. 